### PR TITLE
Updating README to explain different ways of running .exe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ It was made as a final project for my course Introduction to Computing CS101 dur
 
 ## How to Run
 
-If you would like to run the .exe directly from the file explorer:
+### If you would like to run the .exe directly from the file explorer:
 
 Click the code dropdown and download the project folder.
 Navigate to the download location and into the Code folder.
 Right click on the "Typing Tutor.exe" file to run it.
 
-If you would like to work on and run the project within an IDE:
+### If you would like to work on and run the project within an IDE:
 
 Follow the same steps as previous to download the repository.
 Open the project in your IDE.
@@ -36,6 +36,7 @@ Open a terminal window from within the Code folder.
 Powershell:
 Typing ```.\Typing Tutor.exe``` will not work as the name has a space.
 Instead, type the command ```& '.\Typing Tutor.exe'```
+Adding the ```''``` around the file name ensures the entire string is read as the file name.
 A faster way to type this is to start with ```.\Typing``` and then press TAB.
 The TAB will autocomplete the command for you to the command shown above.
 It may autocomplete to ```& '.\Typing Tutor.cbp'```, so just replace the cbp with exe afterwards.
@@ -46,7 +47,7 @@ Git Bash does not recognize the ```&``` so you will just omit it to run the exec
 Note that TAB for autocomplete is not built into Git Bash.
 If you would like to use autocomplete here, download the appropriate bash completion package.
 
-If "Typing Tutor.exe" isn't working then the game can be compiled using any of the two ways:
+### If "Typing Tutor.exe" isn't working then the game can be compiled using any of the two ways:
 
 1) The project is compiled using Code Blocks. So, there is a file named "Typing Tutor.cbp". Open it in Code Blocks and the whole project will load up with all files. Then just click "Build and Run" and the game will start. {Add the libgdi32 library in Code Blocks using project->build options->linker settings-> add button (find libgdi32 for your compiler)} 
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Open a terminal window from within the Code folder.
 
 Powershell:
 Typing ```.\Typing Tutor.exe``` will not work as the name has a space.
-Instead, type the command "& '.\Typing Tutor.exe'"
+Instead, type the command ```& '.\Typing Tutor.exe'```
 A faster way to type this is to start with ```.\Typing``` and then press TAB.
 The TAB will autocomplete the command for you to the command shown above.
 It may autocomplete to ```& '.\Typing Tutor.cbp'```, so just replace the cbp with exe afterwards.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,30 @@ It was made as a final project for my course Introduction to Computing CS101 dur
 
 ## How to Run
 
-There's a file named "Typing Tutor.exe". Just run it and the game will start.
+If you would like to run the .exe directly from the file explorer:
+
+Click the code dropdown and download the project folder.
+Navigate to the download location and into the Code folder.
+Right click on the "Typing Tutor.exe" file to run it.
+
+If you would like to work on and run the project within an IDE:
+
+Follow the same steps as previous to download the repository.
+Open the project in your IDE.
+Open a terminal window from within the Code folder.
+
+Powershell:
+Typing ```.\Typing Tutor.exe``` will not work as the name has a space.
+Instead, type the command "& '.\Typing Tutor.exe'"
+A faster way to type this is to start with ```.\Typing``` and then press TAB.
+The TAB will autocomplete the command for you to the command shown above.
+It may autocomplete to ```& '.\Typing Tutor.cbp'```, so just replace the cbp with exe afterwards.
+
+Git Bash:
+Git Bash does not recognize the ```&``` so you will just omit it to run the executable.
+```'.\Typing Tutor.exe``` will start the game.
+Note that TAB for autocomplete is not built into Git Bash.
+If you would like to use autocomplete here, download the appropriate bash completion package.
 
 If "Typing Tutor.exe" isn't working then the game can be compiled using any of the two ways:
 


### PR DESCRIPTION
Added explanation of running .exe via file explorer and with either PowerShell or Git Bash within an IDE, accounting for the .exe name having a space.